### PR TITLE
feat: publish binaries to github releases as a way to run this tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 reports/
+dist/

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,5 @@
 {
   "name": "@levibostian/decaf-script-github-releases",
-  "version": "0.1.0",
   "license": "MIT",
   "exports": {
     ".": "./script.ts"
@@ -22,6 +21,7 @@
   },
   "tasks": {
     "test": "deno test --allow-all --junit-path reports/junit.xml --coverage=reports/coverage/",
-    "lint": "deno lint --fix"
+    "lint": "deno lint --fix",
+    "compile": "deno compile --output $OUTPUT_FILE_NAME --allow-env --allow-net --allow-run --allow-read --allow-write --target $DENO_TARGET script.ts"
   }
 }

--- a/install
+++ b/install
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="levibostian/decaf-script-github-releases"
+BINARY_NAME="decaf-script-github-releases"
+
+echo "Fetching latest release version from GitHub..."
+LATEST=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+# Detect platform
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+# Map to binary naming convention
+PLATFORM="$OS"
+ARCH_NAME="$ARCH"
+BINARY_FILE="bin-${ARCH_NAME}-${PLATFORM}"
+
+# Allow optional version argument
+VERSION="${1:-$LATEST}"
+
+echo "Installing version: $VERSION - $OS - $ARCH..."
+
+# Download release binary for the specified version
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$BINARY_FILE"
+DEST="./$BINARY_NAME"
+
+if ! curl -fsSL "$DOWNLOAD_URL" -o "$DEST"; then
+    echo "\nNo binary found for OS '$OS' and architecture '$ARCH'." >&2
+    echo "If you believe this is a mistake, please check your release assets or open an issue." >&2
+    exit 1
+fi
+chmod +x "$DEST"
+
+echo "Install complete! Run the tool with:"
+echo "  ./decaf-script-github-releases [args]"

--- a/scripts/deployment-deploy.ts
+++ b/scripts/deployment-deploy.ts
@@ -5,8 +5,38 @@ import { getDeployStepInput } from "@levibostian/decaf-sdk"
 
 const input = getDeployStepInput()
 
-// Deno publish 
+const githubReleaseAssets: string[] = []
 
+const compileBinary = async ({ denoTarget, outputFileName }: { denoTarget: string; outputFileName: string }) => {
+  // Create dist directory if it doesn't exist
+  await $`mkdir -p dist`.printCommand()
+  await $`OUTPUT_FILE_NAME=dist/${outputFileName} DENO_TARGET=${denoTarget} deno task compile`.printCommand()
+
+  githubReleaseAssets.push(`dist/${outputFileName}#${outputFileName}`)
+}
+
+// Compile binaries for different platforms
+await compileBinary({
+  denoTarget: "x86_64-unknown-linux-gnu",
+  outputFileName: "bin-x86_64-Linux",
+})
+
+await compileBinary({
+  denoTarget: "aarch64-unknown-linux-gnu",
+  outputFileName: "bin-aarch64-Linux",
+})
+
+await compileBinary({
+  denoTarget: "x86_64-apple-darwin",
+  outputFileName: "bin-x86_64-Darwin",
+})
+
+await compileBinary({
+  denoTarget: "aarch64-apple-darwin",
+  outputFileName: "bin-aarch64-Darwin",
+})
+
+// Publish the deno module to jsr
 const argsToDenoPublish = [
   "publish",
   "--set-version",
@@ -21,8 +51,7 @@ if (input.testMode) {
 // https://github.com/dsherret/dax#providing-arguments-to-a-command
 await $`deno ${argsToDenoPublish}`.printCommand()
 
-// GitHub Release 
-
+// GitHub Release with binaries
 const argsToCreateGithubRelease = [
   `release`,
   `create`,
@@ -30,14 +59,13 @@ const argsToCreateGithubRelease = [
   `--generate-notes`,
   `--latest`,
   `--target`,
-  'main'
+  'main',
+  ...githubReleaseAssets,
 ]
 
 if (input.testMode) {
   console.log("Running in test mode, skipping creating GitHub release.")
   console.log(`Command to create GitHub release: gh ${argsToCreateGithubRelease.join(" ")}`)
-
-  Deno.exit(0)
+} else {
+  await $`gh ${argsToCreateGithubRelease}`.printCommand()
 }
-
-await $`gh ${argsToCreateGithubRelease}`.printCommand()


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

This script is meant to be run by anyone on any CI server, and Deno is not installed on some CI servers, so I want to try to provide different options for people to run this script. I want to provide a binary that we compile and publish. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

Tested via decaf test mode in this PR

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->