### PR TITLE
 create a node script as an alternative way to run the script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           # required to use 'gh' CLI in my step scripts. 
           GH_TOKEN: ${{ github.token }}      
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           get_latest_release_current_branch: deno run --quiet --allow-all script.ts

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "decaf-script-github-releases",
+  "version": "0.1.0",
+  "description": "A lightweight NPM wrapper for decaf-script-github-releases binary",
+  "type": "module",
+  "main": "script.js",
+  "bin": {
+    "decaf-script-github-releases": "./script.js"
+  },
+  "keywords": [
+    "decaf"    
+  ],
+  "author": "Levi Bostian",
+  "license": "MIT"
+}

--- a/node/package.json
+++ b/node/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "decaf-script-github-releases",
+  "name": "@levibostian/decaf-script-github-releases",
   "version": "0.1.0",
   "description": "A lightweight NPM wrapper for decaf-script-github-releases binary",
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "script.js",
   "bin": {
     "decaf-script-github-releases": "./script.js"

--- a/node/script.js
+++ b/node/script.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process';
+
+// Download and install the binary
+try {
+    execSync('curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash -s "0.2.0" > /dev/null', {
+        stdio: 'inherit',
+        cwd: process.cwd()
+    });
+} catch (error) {
+    console.error('Failed to download binary:', error.message);
+    process.exit(1);
+}
+
+// Run the binary
+const binaryPath = './decaf-script-github-releases';
+try {
+    execSync(binaryPath, {
+        stdio: 'inherit',
+        cwd: process.cwd()
+    });
+} catch (error) {
+    console.error('Failed to run binary:', error.message);
+    process.exit(1);
+}

--- a/node/script.js
+++ b/node/script.js
@@ -1,10 +1,20 @@
 #!/usr/bin/env node
 
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Get the version from package.json
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJsonPath = join(__dirname, 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const version = packageJson.version;
 
 // Download and install the binary
 try {
-    execSync('curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash -s "0.2.0" > /dev/null', {
+    execSync(`curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash -s "${version}" > /dev/null`, {
         stdio: 'inherit',
         cwd: process.cwd()
     });

--- a/scripts/deployment-deploy.ts
+++ b/scripts/deployment-deploy.ts
@@ -15,7 +15,9 @@ const compileBinary = async ({ denoTarget, outputFileName }: { denoTarget: strin
   githubReleaseAssets.push(`dist/${outputFileName}#${outputFileName}`)
 }
 
+// --------------------------------------------------------------------------------
 // Compile binaries for different platforms
+// --------------------------------------------------------------------------------
 await compileBinary({
   denoTarget: "x86_64-unknown-linux-gnu",
   outputFileName: "bin-x86_64-Linux",
@@ -36,7 +38,9 @@ await compileBinary({
   outputFileName: "bin-aarch64-Darwin",
 })
 
+// ---------------------------------------------------------------------------------
 // Publish the deno module to jsr
+// ---------------------------------------------------------------------------------
 const argsToDenoPublish = [
   "publish",
   "--set-version",
@@ -51,7 +55,42 @@ if (input.testMode) {
 // https://github.com/dsherret/dax#providing-arguments-to-a-command
 await $`deno ${argsToDenoPublish}`.printCommand()
 
+// ---------------------------------------------------------------------------------
+// Publish the package to npm
+// ---------------------------------------------------------------------------------
+// update the package.json version before we build as build will define the package we push. 
+
+console.log(`Updating node package version to ${input.nextVersionName}...`)
+await $`npm version ${input.nextVersionName} --no-git-tag-version`.cwd("./node").printCommand() 
+// assert the version was updated correctly. grep will exit with code 1 if it doesn't find the string
+await $`cat node/package.json | grep '"version": "${input.nextVersionName}"'`
+
+console.log(`Testing npm authentication...`)
+await $`npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN`
+await $`npm whoami`.printCommand()
+
+// https://github.com/dsherret/dax#providing-arguments-to-a-command
+const argsToPushToNpm = [
+  `publish`,
+  `node/`
+]
+
+if (input.testMode) {
+  argsToPushToNpm.push(`--dry-run`)
+} 
+
+const nameOfNpmPackage = (await $`npm pkg get name`.cwd("./node").text()).trim().replace(/"/g, "")
+const didAlreadyDeployToNpm = (await $`npx is-it-deployed --package-manager npm --package-name ${nameOfNpmPackage} --package-version 0.1.0`.cwd("./node").noThrow()).code === 0
+
+if (didAlreadyDeployToNpm) {
+  console.log(`npm package ${input.nextVersionName} is already deployed. Skipping pushing to npm`)  
+} else {
+  await $`npm ${argsToPushToNpm}`.printCommand()
+}
+
+// ---------------------------------------------------------------------------------
 // GitHub Release with binaries
+// ---------------------------------------------------------------------------------
 const argsToCreateGithubRelease = [
   `release`,
   `create`,


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

I want people to be able to run this script on their own CI server. And because it's written in Deno, and not a lot of people use Deno, I want to provide an alternative way to run it. So this is to provide a way to run it with Node. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Create a Node script that runs the Deno code. So, we don't have to maintain two separate codebases. All that this script does is download the compiled binary and execute that binary. You can run the script via `npx`. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->