### PR TITLE
ci: setup CI for OIDC publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,20 +10,26 @@ jobs:
     permissions:
       contents: write # If your deploy script that you write needs to push a git commit, git tag, or create a GitHub Release.
       pull-requests: write # If you enable pull request comments (they are enabled by default).
-      id-token: write # required by jsr for publishing package 
+      id-token: write # required by jsr and npm for publishing package 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: v2.x
+
+      # required for OIDC authentication with npm
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest # required to get the latest OIDC support
       
       - uses: levibostian/decaf@0.3.2
         env:
           # required to use 'gh' CLI in my step scripts. 
           GH_TOKEN: ${{ github.token }}      
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           get_latest_release_current_branch: deno run --quiet --allow-all script.ts

--- a/node/package.json
+++ b/node/package.json
@@ -6,6 +6,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/levibostian/decaf-script-github-releases"
+  },
   "main": "script.js",
   "bin": {
     "decaf-script-github-releases": "./script.js"

--- a/scripts/deployment-deploy.ts
+++ b/scripts/deployment-deploy.ts
@@ -65,10 +65,6 @@ await $`npm version ${input.nextVersionName} --no-git-tag-version`.cwd("./node")
 // assert the version was updated correctly. grep will exit with code 1 if it doesn't find the string
 await $`cat node/package.json | grep '"version": "${input.nextVersionName}"'`
 
-console.log(`Testing npm authentication...`)
-await $`npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN`
-await $`npm whoami`.printCommand()
-
 // https://github.com/dsherret/dax#providing-arguments-to-a-command
 const argsToPushToNpm = [
   `publish`,


### PR DESCRIPTION
docs: https://docs.npmjs.com/trusted-publishers

## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

npmjs.com made a change where tokens must now be rotated more often. that's great and all, but not ideal for me with a lot of repos. so, setting up the alternative where tokens are not needed - OIDC. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

modify CI to push to npm without tokens. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

I already ran this setup on another project of mine with success. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->