### PR TITLE
add ability to create a new github release 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}      
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          get_latest_release_current_branch: deno run --quiet --allow-all script.ts
+          get_latest_release_current_branch: deno run --quiet --allow-all script.ts get-latest-release 
           get_next_release_version: ./scripts/deployment-get-next-release.ts
           deploy: ./scripts/deployment-deploy.ts

--- a/README.md
+++ b/README.md
@@ -11,39 +11,117 @@ If you use GitHub's Releases feature to store and track the versions that you de
 This script provides functionality to:
 
 1. **Get the latest release** - Finds the most recent GitHub Release that matches a git tag on the current branch
-2. **Validate release state** - Ensures that git tags have corresponding GitHub Releases
+2. **Set/create a release** - Creates a new GitHub Release with configurable options
+
+## Commands
+
+### Get Latest Release (Default)
+```bash
+# These are all equivalent
+script.ts
+script.ts get
+script.ts get-latest-release
+```
+
+### Set/Create Release
+```bash
+# Create release with default settings
+script.ts set
+script.ts set-latest-release
+
+# Create release with custom arguments
+script.ts set --generate-notes --latest --target main
+script.ts set --draft --notes "Custom release notes"
+```
 
 ## Getting Started
 
-**No installation required!** We just need to tell decaf how to run this script. 
+**No installation required!** We just need to tell decaf how to run this script (via `npx`, `deno`, or a compiled binary).
 
-Doesn't matter how you run decaf (GitHub Actions or CLI), for the *`get_latest_release_current_branch`* argument, you just need to specify how to run it.
+Here are some simple examples for how to run this script with decaf on GitHub Actions or from the command line.
+
+**GitHub Actions Example**
 
 ```yaml
 - uses: levibostian/decaf
   with:
-    get_latest_release_current_branch: npx @levibostian/decaf-script-github-releases
+    get_latest_release_current_branch: npx @levibostian/decaf-script-github-releases get
+    deploy: your-script-here && npx @levibostian/decaf-script-github-releases set
     # Other decaf arguments...
 ```
 
-The above example uses `npx` and is arguably the easiest way to run the script. But, you have a few other options too: 
+**Command Line Example**
 
-1. Run with Deno (requires Deno installed)
-
-```yaml
-get_latest_release_current_branch: deno run --allow-all --quiet jsr:@levibostian/decaf-script-github-releases
+```bash
+decaf \
+  --get-latest-release-current-branch "npx @levibostian/decaf-script-github-releases get" \
+  --deploy "your-script-here && npx @levibostian/decaf-script-github-releases set"
 ```
 
-2. Run as a compiled binary
+> Note: Replace `your-script-here` with whatever commands you need to run as part of the deployment process before creating the release. Be sure to run the script *last* because once you create the release, decaf will consider the deployment successful and if you re-run decaf, it will not attempt to re-attempt the deployment.
+
+### Alternative Installation Methods
+
+The above examples use `npx` and are arguably the easiest way to run the script. But, you have a few other options too: 
+
+1. **Run with Deno** (requires Deno installed)
+
+```yaml
+get_latest_release_current_branch: deno run --allow-all --quiet jsr:@levibostian/decaf-script-github-releases get
+deploy: deno run --allow-all --quiet jsr:@levibostian/decaf-script-github-releases set
+```
+
+2. **Run as a compiled binary**
 
 Great option that doesn't depend on node or deno. This just installs a binary from GitHub and runs it for your operating system.
 
 ```yaml
-# Reminder: replace "0.1.0" with the latest version of the script
-get_latest_release_current_branch: curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash -s "0.1.0" && ./decaf-script-github-releases
+get_latest_release_current_branch: curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash -s "0.1.0" && ./decaf-script-github-releases get
+deploy: curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash -s "0.1.0" && ./decaf-script-github-releases set
 
 # Or, always run the latest version (less stable, but always up-to-date)
-get_latest_release_current_branch: curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash && ./decaf-script-github-releases
+get_latest_release_current_branch: curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash && ./decaf-script-github-releases get
 ```
 
-That's it! decaf will handle the execution and use the results in your deployment workflow.
+### Using Aliases
+
+For convenience, you can also use these aliases:
+
+```bash
+# Instead of 'get', you can use:
+get-latest-release
+
+# Instead of 'set', you can use:
+set-latest-release
+```
+
+### GitHub Release Options
+
+When creating new releases, this script just runs the GitHub CLI under the hood. The script will use a set of default options to create the release, but you can customize it by passing any additional arguments that the GitHub CLI supports.
+
+Example: 
+
+```bash
+# All arguments that you add after 'set' will be passed to the GitHub CLI
+npx @levibostian/decaf-script-github-releases set --draft --target {{gitCurrentBranch}}
+```
+
+### GitHub Release Assets
+
+If you want to upload assets with the GitHub Release, you can provide paths to those assets as output of your own deployment script.
+
+It's a little hacky at the moment because decaf doesn't have this feature built-in at the moment, but you can append custom JSON data to provide to this script like this: 
+
+```typescript
+// In order for the github release deployment script to be able to create a release with these assets, we need to update the input object to include them.
+const outputFileForDeployment = JSON.parse(new TextDecoder("utf-8").decode(Deno.readFileSync(Deno.env.get("DATA_FILE_PATH")!)));
+outputFileForDeployment["@levibostian/decaf-script-github-releases"]["githubReleaseAssets"] = githubReleaseAssets
+
+// Write the updated input back to the file so that the deployment script can read it.
+Deno.writeFileSync(Deno.env.get("DATA_FILE_PATH")!, new TextEncoder().encode(JSON.stringify(outputFileForDeployment)))
+```
+
+This is Deno typescript code, but the concept is the same in any language. Parse the JSON file located at file path specified in the `DATA_FILE_PATH` environment variable, add a key with the name of this package (`@levibostian/decaf-script-github-releases`), and then add a `githubReleaseAssets` array to that object. The value of that array should be strings with the format: `"<path-to-asset>#<name-of-asset>"`. Lastly, write the updated JSON back to the same file path.
+
+See the file `script/deployment-deploy.ts` in this repository for a complete example of how to do this.
+

--- a/README.md
+++ b/README.md
@@ -13,28 +13,7 @@ This script provides functionality to:
 1. **Get the latest release** - Finds the most recent GitHub Release that matches a git tag on the current branch
 2. **Set/create a release** - Creates a new GitHub Release with configurable options
 
-## Commands
-
-### Get Latest Release (Default)
-```bash
-# These are all equivalent
-script.ts
-script.ts get
-script.ts get-latest-release
-```
-
-### Set/Create Release
-```bash
-# Create release with default settings
-script.ts set
-script.ts set-latest-release
-
-# Create release with custom arguments
-script.ts set --generate-notes --latest --target main
-script.ts set --draft --notes "Custom release notes"
-```
-
-## Getting Started
+# Getting Started
 
 **No installation required!** We just need to tell decaf how to run this script (via `npx`, `deno`, or a compiled binary).
 
@@ -83,45 +62,58 @@ deploy: curl -fsSL https://github.com/levibostian/decaf-script-github-releases/b
 get_latest_release_current_branch: curl -fsSL https://github.com/levibostian/decaf-script-github-releases/blob/HEAD/install?raw=true | bash && ./decaf-script-github-releases get
 ```
 
-### Using Aliases
+# Commands
 
-For convenience, you can also use these aliases:
+### Get Latest Release
 
-```bash
-# Instead of 'get', you can use:
-get-latest-release
+In your *get latest release* script for decaf, use the `get` (or `get-latest-release`) command to fetch the latest GitHub Release for the current branch. 
 
-# Instead of 'set', you can use:
-set-latest-release
+If your GitHub repository...
+- ...has a newer git tag then the latest release, this script will return the release, not the tag. 
+- ...has no releases, it will return nothing, indicating that there is no latest release. 
+- ...has newer GitHub Releases then the current branch's latest git tag, it will return the older GitHub Release that matches the latest git tag on the current branch.
+
+Example usage:
+
+```bash 
+npx @levibostian/decaf-script-github-releases get
 ```
 
-### GitHub Release Options
+### Set/Create Release
 
-When creating new releases, this script just runs the GitHub CLI under the hood. The script will use a set of default options to create the release, but you can customize it by passing any additional arguments that the GitHub CLI supports.
+In your *deploy* script for decaf, use the `set` (or `set-latest-release`) command to create a new GitHub Release for the current branch.
 
-Example: 
+When you run this command, it will:
+- Create a new GitHub Release using the new version determined by the decaf get next release version script 
+- Upload any assets that you created if you called the `set-assets` command beforehand
+
+Example usage:
 
 ```bash
-# All arguments that you add after 'set' will be passed to the GitHub CLI
+# Use the default settings to create the release
+npx @levibostian/decaf-script-github-releases set
+
+# Or, with custom GitHub CLI arguments
 npx @levibostian/decaf-script-github-releases set --draft --target {{gitCurrentBranch}}
 ```
 
-### GitHub Release Assets
+### Set GitHub Release Assets
 
-If you want to upload assets with the GitHub Release, you can provide paths to those assets as output of your own deployment script.
+In your *deploy* script for decaf, use the `set-assets` (or `set-github-release-assets`) command to specify files that should be uploaded when creating a GitHub Release (when you call `set` command).
 
-It's a little hacky at the moment because decaf doesn't have this feature built-in at the moment, but you can append custom JSON data to provide to this script like this: 
+This command allows you to:
+- Specify multiple files to upload as release assets
+- Set custom display names for each asset
 
-```typescript
-// In order for the github release deployment script to be able to create a release with these assets, we need to update the input object to include them.
-const outputFileForDeployment = JSON.parse(new TextDecoder("utf-8").decode(Deno.readFileSync(Deno.env.get("DATA_FILE_PATH")!)));
-outputFileForDeployment["@levibostian/decaf-script-github-releases"]["githubReleaseAssets"] = githubReleaseAssets
+Example usage:
 
-// Write the updated input back to the file so that the deployment script can read it.
-Deno.writeFileSync(Deno.env.get("DATA_FILE_PATH")!, new TextEncoder().encode(JSON.stringify(outputFileForDeployment)))
+```bash
+# After your deployment script runs, set the assets to upload. 
+# Each asset follows the format: `"path/to/file#Display Name"`
+npx @levibostian/decaf-script-github-releases set-assets "dist/binary-linux#Linux Binary" "dist/binary-mac#Mac Binary"
+
+# Then create the release (it will automatically include the assets)
+npx @levibostian/decaf-script-github-releases set
 ```
 
-This is Deno typescript code, but the concept is the same in any language. Parse the JSON file located at file path specified in the `DATA_FILE_PATH` environment variable, add a key with the name of this package (`@levibostian/decaf-script-github-releases`), and then add a `githubReleaseAssets` array to that object. The value of that array should be strings with the format: `"<path-to-asset>#<name-of-asset>"`. Lastly, write the updated JSON back to the same file path.
-
-See the file `script/deployment-deploy.ts` in this repository for a complete example of how to do this.
 

--- a/node/script.js
+++ b/node/script.js
@@ -4,6 +4,7 @@ import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import process from "node:process";
 
 // Get the version from package.json
 const __filename = fileURLToPath(import.meta.url);
@@ -11,6 +12,10 @@ const __dirname = dirname(__filename);
 const packageJsonPath = join(__dirname, 'package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 const version = packageJson.version;
+
+// Get command line arguments (skip node and script name)
+const args = process.argv.slice(2);
+const argsString = args.length > 0 ? ` ${args.join(' ')}` : '';
 
 // Download and install the binary
 try {
@@ -23,10 +28,10 @@ try {
     process.exit(1);
 }
 
-// Run the binary
+// Run the binary with arguments
 const binaryPath = './decaf-script-github-releases';
 try {
-    execSync(binaryPath, {
+    execSync(`${binaryPath}${argsString}`, {
         stdio: 'inherit',
         cwd: process.cwd()
     });

--- a/script.test.ts
+++ b/script.test.ts
@@ -1,13 +1,17 @@
 import type {
   GetLatestReleaseStepInput,
   GetLatestReleaseStepOutput,
+  DeployStepInput,
   GitCommit,
 } from "@levibostian/decaf-sdk";
-import { assertEquals } from "@std/assert"
+import { assertEquals, assertStringIncludes } from "@std/assert"
 
 // a decaf script test runner essentially. Copied from decaf: https://github.com/levibostian/decaf/blob/a0e324f7209c0f37b9d275b7259fcefd591a17c6/steps/get-next-release.test.ts#L4
 // would be nice to put into decaf or the sdks in the future. 
-async function runStep(input: GetLatestReleaseStepInput, mockGitHubReleases: {name: string; tagName: string}[]): Promise<{code: number; output: GetLatestReleaseStepOutput | null}> {
+async function runScript(input: GetLatestReleaseStepInput | DeployStepInput, args: string[], mockGitHubReleases: {name: string; tagName: string}[]): Promise<{code: number; output: GetLatestReleaseStepOutput | null, stdout: string}> {
+  // make test mode always enabled. instead of mocking running commands, we rely on the testMode flag to not actually run commands.
+  input.testMode = true;
+
   // Write input to a temp file
   const tempFile = await Deno.makeTempFile()
   const inputFileContents = JSON.stringify(input)
@@ -25,19 +29,21 @@ async function runStep(input: GetLatestReleaseStepInput, mockGitHubReleases: {na
   env.MOCK_GITHUB_RELEASES = JSON.stringify(mockGitHubReleases);
 
   const process = new Deno.Command("deno", {
-    args: ["run", "--allow-all", scriptPath, "--config", JSON.stringify({})],
+    args: ["run", "--allow-all", scriptPath, ...args],
     env,
+    stdout: "piped",
   })
 
   const child = process.spawn()
-  const code = (await child.status).code
+  const { code, stdout } = await child.output()
+  
   const outputFileContents = await Deno.readTextFile(tempFile)
   let output: GetLatestReleaseStepOutput | null = null
   if (outputFileContents != inputFileContents) {
     output = JSON.parse(outputFileContents)
   }
 
-  return { code, output }
+  return { code, output, stdout: new TextDecoder().decode(stdout) }
 }
 
 Deno.test("given no tags on the current branch, expect null for latest release", async () => {
@@ -45,8 +51,7 @@ Deno.test("given no tags on the current branch, expect null for latest release",
     gitCurrentBranch: "main",
     gitRepoOwner: "levibostian",
     gitRepoName: "decaf-script-github-releases",
-    testMode: true,
-    gitCommitsCurrentBranch: [
+        gitCommitsCurrentBranch: [
       {
         sha: "abc1",
         title: "Initial commit",
@@ -61,9 +66,9 @@ Deno.test("given no tags on the current branch, expect null for latest release",
       }
     ] as unknown as GitCommit[],
     gitCommitsAllLocalBranches: {}
-  }
+  } as unknown as GetLatestReleaseStepInput;
 
-  const { code, output } = await runStep(input, [])
+  const { code, output } = await runScript(input, ["get"], [])
 
   assertEquals(code, 0)
   assertEquals(output, null)
@@ -74,8 +79,7 @@ Deno.test("given git tags exist and matching GitHub release exists, expect relea
     gitCurrentBranch: "main",
     gitRepoOwner: "levibostian",
     gitRepoName: "decaf-script-github-releases",
-    testMode: true,
-    gitCommitsCurrentBranch: [
+        gitCommitsCurrentBranch: [
       {
         sha: "abc1",
         title: "Initial commit",
@@ -90,9 +94,9 @@ Deno.test("given git tags exist and matching GitHub release exists, expect relea
       }
     ] as unknown as GitCommit[],
     gitCommitsAllLocalBranches: {}
-  }
+  } as unknown as GetLatestReleaseStepInput;
 
-  const { code, output } = await runStep(input, [
+  const { code, output } = await runScript(input, ["get"], [
     { name: "Release v1.0.0", tagName: "v1.0.0" },
     { name: "Release v0.9.0", tagName: "v0.9.0" }
   ])
@@ -109,8 +113,7 @@ Deno.test("given multiple commits with tags, should use the first (latest) commi
     gitCurrentBranch: "main",
     gitRepoOwner: "levibostian",
     gitRepoName: "decaf-script-github-releases",
-    testMode: true,
-    gitCommitsCurrentBranch: [     
+        gitCommitsCurrentBranch: [     
       {
         sha: "abc2",
         title: "Release v2.0.0",
@@ -131,9 +134,9 @@ Deno.test("given multiple commits with tags, should use the first (latest) commi
       },
     ] as unknown as GitCommit[],
     gitCommitsAllLocalBranches: {}
-  }
+  } as unknown as GetLatestReleaseStepInput;
 
-  const { code, output } = await runStep(input, [
+  const { code, output } = await runScript(input, ["get"], [
     { name: "Release v2.0.0", tagName: "v2.0.0" },
     { name: "Release v1.0.0", tagName: "v1.0.0" }
   ])
@@ -150,8 +153,7 @@ Deno.test("given git tags exist but no GitHub releases, expect null", async () =
     gitCurrentBranch: "main",
     gitRepoOwner: "levibostian",
     gitRepoName: "decaf-script-github-releases",
-    testMode: true,
-    gitCommitsCurrentBranch: [
+        gitCommitsCurrentBranch: [
       {
         sha: "abc1",
         title: "Initial commit",
@@ -166,10 +168,10 @@ Deno.test("given git tags exist but no GitHub releases, expect null", async () =
       }
     ] as unknown as GitCommit[],
     gitCommitsAllLocalBranches: {}
-  }
+  } as unknown as GetLatestReleaseStepInput;
 
   // Mock no GitHub releases
-  const { code, output } = await runStep(input, [])
+  const { code, output } = await runScript(input, ["get"], [])
 
   assertEquals(code, 0)
   assertEquals(output, null)
@@ -180,8 +182,7 @@ Deno.test("given git tags exist and GitHub releases exist but no matching releas
     gitCurrentBranch: "main",
     gitRepoOwner: "levibostian",
     gitRepoName: "decaf-script-github-releases",
-    testMode: true,
-    gitCommitsCurrentBranch: [
+        gitCommitsCurrentBranch: [
       {
         sha: "abc1",
         title: "Initial commit",
@@ -196,7 +197,7 @@ Deno.test("given git tags exist and GitHub releases exist but no matching releas
       }
     ] as unknown as GitCommit[],
     gitCommitsAllLocalBranches: {}
-  }
+  } as unknown as GetLatestReleaseStepInput;
 
   // Mock GitHub releases that don't match the latest tag
   const mockReleases = [
@@ -204,7 +205,7 @@ Deno.test("given git tags exist and GitHub releases exist but no matching releas
     { name: "Release v1.1.0", tagName: "v1.1.0" }
   ];
 
-  const { code, output } = await runStep(input, mockReleases)
+  const { code, output } = await runScript(input, ["get"], mockReleases)
 
   assertEquals(code, 0)
   assertEquals(output, null)
@@ -215,8 +216,7 @@ Deno.test("given on a maintenance branch with newer releases available on main b
     gitCurrentBranch: "v1", // a maintenance branch
     gitRepoOwner: "levibostian",
     gitRepoName: "decaf-script-github-releases",
-    testMode: true,
-    gitCommitsCurrentBranch: [      
+        gitCommitsCurrentBranch: [      
       {
         sha: "abc2",
         title: "Patch release v1.5.1",
@@ -231,7 +231,7 @@ Deno.test("given on a maintenance branch with newer releases available on main b
       },
     ] as unknown as GitCommit[],
     gitCommitsAllLocalBranches: {}
-  }
+  } as unknown as GetLatestReleaseStepInput;
 
   // Mock GitHub releases including newer releases (v3.0.0, v2.0.0) but also the one matching our branch (v1.5.1)
   const mockReleases = [
@@ -243,11 +243,103 @@ Deno.test("given on a maintenance branch with newer releases available on main b
     { name: "Release v1.0.0", tagName: "v1.0.0" }  // Even older release
   ];
 
-  const { code, output } = await runStep(input, mockReleases)
+  const { code, output } = await runScript(input, ["get"], mockReleases)
 
   assertEquals(code, 0)
   assertEquals(output, {
     versionName: "Release v1.5.1",
     commitSha: "abc2"
-  })
-})
+  });
+});
+
+Deno.test("set command with default arguments should generate correct gh command", async () => {
+  const input = {
+    nextVersionName: "v1.0.0",
+        gitCurrentBranch: "foo",
+    "@levibostian/decaf-script-github-releases": {
+      githubReleaseAssets: []
+    }
+  } as unknown as DeployStepInput;
+
+  const { code, stdout } = await runScript(input, ["set"], []);
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "Running in test mode, skipping creating GitHub release.");
+  assertStringIncludes(stdout, "gh release create v1.0.0 --generate-notes --latest --target foo");
+});
+
+Deno.test("set command with custom arguments should override defaults", async () => {
+  const input = {
+    nextVersionName: "v2.0.0",
+        "@levibostian/decaf-script-github-releases": {
+      githubReleaseAssets: []
+    }
+  } as unknown as DeployStepInput;
+
+  const { code, stdout } = await runScript(input, ["set", "--draft", "--notes", "Custom release notes"], []);
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "Running in test mode, skipping creating GitHub release.");
+  assertStringIncludes(stdout, "gh release create v2.0.0 --draft --notes Custom release notes");
+});
+
+Deno.test("set command with GitHub release assets should include them in command", async () => {
+  const input = {
+    nextVersionName: "v1.2.0",
+        gitCurrentBranch: "develop",
+    "@levibostian/decaf-script-github-releases": {
+      githubReleaseAssets: ["dist/binary-linux#Linux Binary", "dist/binary-mac#Mac Binary"]
+    }
+  } as unknown as DeployStepInput;
+
+  const { code, stdout } = await runScript(input, ["set"], []);
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "Running in test mode, skipping creating GitHub release.");
+  assertStringIncludes(stdout, "gh release create v1.2.0 --generate-notes --latest --target develop dist/binary-linux#Linux Binary dist/binary-mac#Mac Binary");
+}); 
+
+Deno.test("set-latest-release alias should work the same as set", async () => {
+  const input = {
+    nextVersionName: "v1.0.0",
+    gitCurrentBranch: "main",
+    "@levibostian/decaf-script-github-releases": {
+      githubReleaseAssets: []
+    }
+  } as unknown as DeployStepInput;
+
+  // Test with 'set'
+  const { stdout: setOutput } = await runScript(input, ["set"], []);
+
+  // Test with 'set-latest-release'
+  const { stdout: aliasOutput } = await runScript(input, ["set-latest-release"], []);
+
+  // Both should produce the same output
+  assertEquals(setOutput, aliasOutput);
+});
+
+Deno.test("no command specified should default to get behavior", async () => {
+  const input: GetLatestReleaseStepInput = {
+    gitCurrentBranch: "main",
+    gitRepoOwner: "levibostian", 
+    gitRepoName: "decaf-script-github-releases",
+        gitCommitsCurrentBranch: [
+      {
+        sha: "abc2",
+        title: "Release v1.0.0",
+        tags: ["v1.0.0"],
+        message: "Release v1.0.0",
+      }
+    ] as unknown as GitCommit[],
+    gitCommitsAllLocalBranches: {}
+  } as unknown as GetLatestReleaseStepInput;
+
+  // Test with no arguments (should default to 'get')
+  const { code, stdout } = await runScript(input, [], [
+    { name: "Release v1.0.0", tagName: "v1.0.0" }
+  ]);
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "Latest git tag on the current branch is: v1.0.0");
+  assertStringIncludes(stdout, "latest release found: Release v1.0.0 (v1.0.0)");
+});

--- a/script.test.ts
+++ b/script.test.ts
@@ -32,10 +32,11 @@ async function runScript(input: GetLatestReleaseStepInput | DeployStepInput, arg
     args: ["run", "--allow-all", scriptPath, ...args],
     env,
     stdout: "piped",
+    stderr: "piped",
   })
 
   const child = process.spawn()
-  const { code, stdout } = await child.output()
+  const { code, stdout, stderr } = await child.output()
   
   const outputFileContents = await Deno.readTextFile(tempFile)
   let output: GetLatestReleaseStepOutput | null = null
@@ -43,7 +44,10 @@ async function runScript(input: GetLatestReleaseStepInput | DeployStepInput, arg
     output = JSON.parse(outputFileContents)
   }
 
-  return { code, output, stdout: new TextDecoder().decode(stdout) }
+  // Combine stdout and stderr for the test assertions
+  const combinedOutput = new TextDecoder().decode(stdout) + new TextDecoder().decode(stderr)
+
+  return { code, output, stdout: combinedOutput }
 }
 
 Deno.test("given no tags on the current branch, expect null for latest release", async () => {
@@ -255,10 +259,7 @@ Deno.test("given on a maintenance branch with newer releases available on main b
 Deno.test("set command with default arguments should generate correct gh command", async () => {
   const input = {
     nextVersionName: "v1.0.0",
-        gitCurrentBranch: "foo",
-    "@levibostian/decaf-script-github-releases": {
-      githubReleaseAssets: []
-    }
+    gitCurrentBranch: "foo"
   } as unknown as DeployStepInput;
 
   const { code, stdout } = await runScript(input, ["set"], []);
@@ -270,10 +271,7 @@ Deno.test("set command with default arguments should generate correct gh command
 
 Deno.test("set command with custom arguments should override defaults", async () => {
   const input = {
-    nextVersionName: "v2.0.0",
-        "@levibostian/decaf-script-github-releases": {
-      githubReleaseAssets: []
-    }
+    nextVersionName: "v2.0.0"
   } as unknown as DeployStepInput;
 
   const { code, stdout } = await runScript(input, ["set", "--draft", "--notes", "Custom release notes"], []);
@@ -284,28 +282,34 @@ Deno.test("set command with custom arguments should override defaults", async ()
 });
 
 Deno.test("set command with GitHub release assets should include them in command", async () => {
+  // Create temporary test files for assets
+  const tempDir = await Deno.makeTempDir();
+  const linuxBinary = `${tempDir}/binary-linux`;
+  const macBinary = `${tempDir}/binary-mac`;
+  
+  await Deno.writeTextFile(linuxBinary, "linux binary content");
+  await Deno.writeTextFile(macBinary, "mac binary content");
+
+  // First, set up assets using set-assets
+  await runScript({} as unknown as DeployStepInput, ["set-assets", `${linuxBinary}#Linux Binary`, `${macBinary}#Mac Binary`], []);
+
+  // Then try to create a release - it should pick up the assets from the temp file
   const input = {
     nextVersionName: "v1.2.0",
-        gitCurrentBranch: "develop",
-    "@levibostian/decaf-script-github-releases": {
-      githubReleaseAssets: ["dist/binary-linux#Linux Binary", "dist/binary-mac#Mac Binary"]
-    }
+    gitCurrentBranch: "develop"
   } as unknown as DeployStepInput;
 
   const { code, stdout } = await runScript(input, ["set"], []);
 
   assertEquals(code, 0);
   assertStringIncludes(stdout, "Running in test mode, skipping creating GitHub release.");
-  assertStringIncludes(stdout, "gh release create v1.2.0 --generate-notes --latest --target develop dist/binary-linux#Linux Binary dist/binary-mac#Mac Binary");
+  assertStringIncludes(stdout, `gh release create v1.2.0 --generate-notes --latest --target develop ${linuxBinary}#Linux Binary ${macBinary}#Mac Binary`);
 }); 
 
 Deno.test("set-latest-release alias should work the same as set", async () => {
   const input = {
     nextVersionName: "v1.0.0",
-    gitCurrentBranch: "main",
-    "@levibostian/decaf-script-github-releases": {
-      githubReleaseAssets: []
-    }
+    gitCurrentBranch: "main"
   } as unknown as DeployStepInput;
 
   // Test with 'set'
@@ -342,4 +346,125 @@ Deno.test("no command specified should default to get behavior", async () => {
   assertEquals(code, 0);
   assertStringIncludes(stdout, "Latest git tag on the current branch is: v1.0.0");
   assertStringIncludes(stdout, "latest release found: Release v1.0.0 (v1.0.0)");
+});
+
+Deno.test("set-assets command should save assets to temp file", async () => {
+  // Create temporary test files for assets
+  const tempDir = await Deno.makeTempDir();
+  const linuxBinary = `${tempDir}/binary-linux`;
+  const macBinary = `${tempDir}/binary-mac`;
+  
+  await Deno.writeTextFile(linuxBinary, "linux binary content");
+  await Deno.writeTextFile(macBinary, "mac binary content");
+
+  // We need a basic input even though this command doesn't use it much
+  const input = {} as unknown as DeployStepInput;
+
+  const { code, stdout } = await runScript(input, ["set-assets", `${linuxBinary}#Linux Binary`, `${macBinary}#Mac Binary`], []);
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "GitHub Release assets:");
+  assertStringIncludes(stdout, `${linuxBinary}#Linux Binary`);
+  assertStringIncludes(stdout, `${macBinary}#Mac Binary`);
+});
+
+Deno.test("set-github-release-assets alias should work the same as set-assets", async () => {
+  // Create temporary test file for asset
+  const tempDir = await Deno.makeTempDir();
+  const testFile = `${tempDir}/test`;
+  
+  await Deno.writeTextFile(testFile, "test content");
+
+  const input = {} as unknown as DeployStepInput;
+
+  const { code: code1, stdout: stdout1 } = await runScript(input, ["set-assets", `${testFile}#Test File`], []);
+  const { code: code2, stdout: stdout2 } = await runScript(input, ["set-github-release-assets", `${testFile}#Test File`], []);
+
+  assertEquals(code1, 0);
+  assertEquals(code2, 0);
+  // Both should mention saving assets
+  assertStringIncludes(stdout1, "GitHub Release assets:");
+  assertStringIncludes(stdout2, "GitHub Release assets:");
+});
+
+Deno.test("set-assets command should require at least one asset", async () => {
+  const input = {} as unknown as DeployStepInput;
+
+  const { code, stdout } = await runScript(input, ["set-assets"], []);
+
+  assertEquals(code, 1);
+  assertStringIncludes(stdout, "Error: set-assets command requires at least one asset argument");
+});
+
+Deno.test("set-assets should verify asset files exist before saving", async () => {
+  // Create temporary test files
+  const tempDir = await Deno.makeTempDir();
+  const validFile1 = `${tempDir}/valid-file-1.txt`;
+  const validFile2 = `${tempDir}/valid-file-2.bin`;
+  const nonExistentFile = `${tempDir}/non-existent.txt`;
+  
+  await Deno.writeTextFile(validFile1, "test content 1");
+  await Deno.writeTextFile(validFile2, "test content 2");
+  
+  const input = {} as unknown as DeployStepInput;
+
+  // Test with valid files (with and without hash labels)
+  const { code: validCode, stdout: validStdout } = await runScript(input, [
+    "set-assets", 
+    validFile1,  // No hash label
+    `${validFile2}#Binary File`  // With hash label
+  ], []);
+
+  assertEquals(validCode, 0);
+  assertStringIncludes(validStdout, "GitHub Release assets:");
+  assertStringIncludes(validStdout, validFile1);
+  assertStringIncludes(validStdout, `${validFile2}#Binary File`);
+
+  // Test with non-existent file
+  const { code: invalidCode, stdout: invalidStdout } = await runScript(input, [
+    "set-assets", 
+    nonExistentFile
+  ], []);
+
+  assertEquals(invalidCode, 1);
+  assertStringIncludes(invalidStdout, `Given asset, ${nonExistentFile}, file does not exist. Cannot proceed.`);
+
+  // Test with directory instead of file
+  const { code: dirCode, stdout: dirStdout } = await runScript(input, [
+    "set-assets", 
+    tempDir  // This is a directory, not a file
+  ], []);
+
+  assertEquals(dirCode, 1);
+  assertStringIncludes(dirStdout, `Given asset, ${tempDir}, is not a file. Cannot proceed.`);
+});
+
+Deno.test("set-assets should handle mixed asset formats (with and without hash)", async () => {
+  // Create temporary test files
+  const tempDir = await Deno.makeTempDir();
+  const binaryFile = `${tempDir}/app.exe`;
+  const docFile = `${tempDir}/readme.txt`;
+  const configFile = `${tempDir}/config.json`;
+  
+  await Deno.writeTextFile(binaryFile, "binary content");
+  await Deno.writeTextFile(docFile, "documentation");
+  await Deno.writeTextFile(configFile, '{"version": "1.0"}');
+  
+  const input = {} as unknown as DeployStepInput;
+
+  // Test with mix of assets with and without hash labels
+  const { code, stdout } = await runScript(input, [
+    "set-assets",
+    binaryFile,  // No hash
+    `${docFile}#Documentation`,  // With hash
+    configFile,  // No hash
+    `${configFile}#Configuration File`  // Same file with different hash
+  ], []);
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "GitHub Release assets:");
+  assertStringIncludes(stdout, binaryFile);
+  assertStringIncludes(stdout, `${docFile}#Documentation`);
+  assertStringIncludes(stdout, configFile);
+  assertStringIncludes(stdout, `${configFile}#Configuration File`);
 });

--- a/script.ts
+++ b/script.ts
@@ -1,7 +1,8 @@
 import {
   getLatestReleaseStepInput,
   type GetLatestReleaseStepOutput,
-  setLatestReleaseStepOutput
+  setLatestReleaseStepOutput,
+  getDeployStepInput
 } from "@levibostian/decaf-sdk";
 import $ from "@david/dax";
 
@@ -51,9 +52,104 @@ export const getLatestReleaseFromGitHubReleases = async (): Promise<GetLatestRel
   }
 }
 
+export const createGitHubRelease = async (customArgs: string[] = []): Promise<void> => {
+  const input = getDeployStepInput();
+  const inputAsUnknown = input as unknown as { "@levibostian/decaf-script-github-releases": { githubReleaseAssets?: string[] } };
+  
+  // Get assets from input if they exist
+  const githubReleaseAssets = inputAsUnknown["@levibostian/decaf-script-github-releases"].githubReleaseAssets || [];
+  
+  // Get current branch from input
+  const currentBranch = input.gitCurrentBranch;
+  
+  let argsToCreateGithubRelease: string[];
+  
+  if (customArgs.length > 0) {
+    // User provided custom arguments, use them directly
+    argsToCreateGithubRelease = [
+      'release',
+      'create',
+      input.nextVersionName,
+      ...customArgs,
+      ...githubReleaseAssets,
+    ];
+  } else {
+    // Use default arguments
+    argsToCreateGithubRelease = [
+      'release',
+      'create', 
+      input.nextVersionName,
+      '--generate-notes',
+      '--latest',
+      '--target',
+      currentBranch,
+      ...githubReleaseAssets,
+    ];
+  }
+
+  if (input.testMode) {
+    console.log("Running in test mode, skipping creating GitHub release.");
+    console.log(`Command to create GitHub release: gh ${argsToCreateGithubRelease.join(" ")}`);
+  } else {
+    await $`gh ${argsToCreateGithubRelease}`.printCommand();
+  }
+}
+
+function showHelp() {
+  console.log(`
+Usage: 
+  script.ts get                           # Get the latest release (default behavior)
+  script.ts set [args...]                 # Set/create a GitHub release
+  script.ts get-latest-release            # Alias for 'get'
+  script.ts set-latest-release [args...]  # Alias for 'set'
+
+Commands:
+  get, get-latest-release    Get the latest GitHub release that matches a git tag on the current branch
+  set, set-latest-release    Create a new GitHub release
+
+Examples:
+  # Get latest release
+  script.ts get
+  script.ts get-latest-release
+
+  # Create release with default settings
+  script.ts set
+  script.ts set-latest-release
+
+  # Create release with custom arguments
+  script.ts set --generate-notes --latest --target main
+  script.ts set-latest-release --draft --notes "Custom release notes"
+`);
+}
+
 if (import.meta.main) {
-  const latestRelease = await getLatestReleaseFromGitHubReleases();
-  if (latestRelease) {
-    setLatestReleaseStepOutput(latestRelease);
+  // Check for help flag
+  if (Deno.args.includes("--help") || Deno.args.includes("-h")) {
+    showHelp();
+    Deno.exit(0);
+  }
+
+  const command = Deno.args.length > 0 ? Deno.args[0] : "get";
+  const commandArgs = Deno.args.slice(1);
+
+  switch (command) {
+    case "get":
+    case "get-latest-release": {
+      const latestRelease = await getLatestReleaseFromGitHubReleases();
+      if (latestRelease) {
+        setLatestReleaseStepOutput(latestRelease);
+      }
+      break;
+    }
+    case "set":
+    case "set-latest-release": {
+      await createGitHubRelease(commandArgs);
+      break;
+    }
+    default: {
+      console.error(`Unknown command: ${command}`);
+      showHelp();
+      Deno.exit(1);
+    }
   }
 }

--- a/script.ts
+++ b/script.ts
@@ -6,6 +6,15 @@ import {
 } from "@levibostian/decaf-sdk";
 import $ from "@david/dax";
 
+interface ScriptDataSavedToFile {
+  githubReleaseAssets: string[];
+}
+const getFileToSaveScriptDataTo = (): string => {
+  const tempDir = Deno.env.get("TMPDIR") || Deno.env.get("TMP") || "/tmp";
+    const assetsFilePath = `${tempDir}/decaf-script-github-releases-assets.json`;
+  return assetsFilePath;
+}
+
 export const getLatestReleaseFromGitHubReleases = async (): Promise<GetLatestReleaseStepOutput | null> => {
   const input = getLatestReleaseStepInput();
 
@@ -54,10 +63,16 @@ export const getLatestReleaseFromGitHubReleases = async (): Promise<GetLatestRel
 
 export const createGitHubRelease = async (customArgs: string[] = []): Promise<void> => {
   const input = getDeployStepInput();
-  const inputAsUnknown = input as unknown as { "@levibostian/decaf-script-github-releases": { githubReleaseAssets?: string[] } };
   
-  // Get assets from input if they exist
-  const githubReleaseAssets = inputAsUnknown["@levibostian/decaf-script-github-releases"].githubReleaseAssets || [];
+  // Get assets from temp file created by set-assets command
+  let githubReleaseAssets: string[] = [];
+  try {
+    const assetsFilePath = getFileToSaveScriptDataTo();
+    const assetsData: ScriptDataSavedToFile = JSON.parse(await Deno.readTextFile(assetsFilePath));
+    githubReleaseAssets = assetsData.githubReleaseAssets || [];
+  } catch {
+    // No temp file or error reading it, continue with empty assets
+  }
   
   // Get current branch from input
   const currentBranch = input.gitCurrentBranch;
@@ -95,17 +110,54 @@ export const createGitHubRelease = async (customArgs: string[] = []): Promise<vo
   }
 }
 
+export const setGitHubReleaseAssets = async (assets: string[]): Promise<void> => {  
+  // Verify all asset paths exist
+  for (const asset of assets) {
+    const assetPath = asset.split("#")[0];
+    try {
+      const stat = await Deno.stat(assetPath);
+      if (!stat.isFile) {
+        console.error(`Given asset, ${assetPath}, is not a file. Cannot proceed.`);
+        Deno.exit(1);
+      }
+    } catch {
+      console.error(`Given asset, ${assetPath}, file does not exist. Cannot proceed.`);
+      Deno.exit(1);
+    }
+  }
+
+  // Get the temporary directory
+  const assetsFilePath = getFileToSaveScriptDataTo();
+  
+  // Create the assets data
+  const assetsData: ScriptDataSavedToFile = {
+    githubReleaseAssets: assets
+  };
+  
+  // Write to temp file
+  try {
+    await Deno.writeTextFile(assetsFilePath, JSON.stringify(assetsData, null, 2));
+    console.log(`GitHub Release assets: ${assets.join(", ")} saved to be referenced later when creating a release.`);
+  } catch (error) {
+    console.error(`Failed to write assets file: ${error instanceof Error ? error.message : String(error)}`);
+    Deno.exit(1);
+  }
+}
+
 function showHelp() {
   console.log(`
 Usage: 
   script.ts get                           # Get the latest release (default behavior)
   script.ts set [args...]                 # Set/create a GitHub release
+  script.ts set-assets <asset1> [asset2...]  # Set GitHub release assets
   script.ts get-latest-release            # Alias for 'get'
   script.ts set-latest-release [args...]  # Alias for 'set'
+  script.ts set-github-release-assets <asset1> [asset2...]  # Alias for 'set-assets'
 
 Commands:
-  get, get-latest-release    Get the latest GitHub release that matches a git tag on the current branch
-  set, set-latest-release    Create a new GitHub release
+  get, get-latest-release                Get the latest GitHub release that matches a git tag on the current branch
+  set, set-latest-release                Create a new GitHub release
+  set-assets, set-github-release-assets  Set GitHub release assets for future release creation
 
 Examples:
   # Get latest release
@@ -119,6 +171,10 @@ Examples:
   # Create release with custom arguments
   script.ts set --generate-notes --latest --target main
   script.ts set-latest-release --draft --notes "Custom release notes"
+
+  # Set assets for future release
+  script.ts set-assets "dist/binary-linux#Linux Binary" "dist/binary-mac#Mac Binary"
+  script.ts set-github-release-assets "docs/manual.pdf#User Manual"
 `);
 }
 
@@ -144,6 +200,18 @@ if (import.meta.main) {
     case "set":
     case "set-latest-release": {
       await createGitHubRelease(commandArgs);
+      break;
+    }
+    case "set-assets":
+    case "set-github-release-assets": {
+      if (commandArgs.length === 0) {
+        console.error("Error: set-assets command requires at least one asset argument");
+        console.error("Usage: script.ts set-assets <asset1> [asset2...]");
+        console.error("Asset format: path#name (e.g., 'dist/binary#Binary File')");
+        
+        Deno.exit(1);
+      }
+      await setGitHubReleaseAssets(commandArgs);
       break;
     }
     default: {

--- a/scripts/deployment-deploy.ts
+++ b/scripts/deployment-deploy.ts
@@ -38,6 +38,13 @@ await compileBinary({
   outputFileName: "bin-aarch64-Darwin",
 })
 
+// In order for the github release deployment script to be able to create a release with these assets, we need to update the input object to include them.
+const outputFileForDeployment = JSON.parse(new TextDecoder("utf-8").decode(Deno.readFileSync(Deno.env.get("DATA_FILE_PATH")!)));
+outputFileForDeployment["@levibostian/decaf-script-github-releases"]["githubReleaseAssets"] = githubReleaseAssets
+
+// Write the updated input back to the file so that the deployment script can read it.
+Deno.writeFileSync(Deno.env.get("DATA_FILE_PATH")!, new TextEncoder().encode(JSON.stringify(outputFileForDeployment)))
+
 // ---------------------------------------------------------------------------------
 // Publish the deno module to jsr
 // ---------------------------------------------------------------------------------
@@ -82,25 +89,4 @@ if (didAlreadyDeployToNpm) {
   console.log(`npm package ${input.nextVersionName} is already deployed. Skipping pushing to npm`)  
 } else {
   await $`npm ${argsToPushToNpm}`.printCommand()
-}
-
-// ---------------------------------------------------------------------------------
-// GitHub Release with binaries
-// ---------------------------------------------------------------------------------
-const argsToCreateGithubRelease = [
-  `release`,
-  `create`,
-  input.nextVersionName,
-  `--generate-notes`,
-  `--latest`,
-  `--target`,
-  'main',
-  ...githubReleaseAssets,
-]
-
-if (input.testMode) {
-  console.log("Running in test mode, skipping creating GitHub release.")
-  console.log(`Command to create GitHub release: gh ${argsToCreateGithubRelease.join(" ")}`)
-} else {
-  await $`gh ${argsToCreateGithubRelease}`.printCommand()
 }

--- a/scripts/deployment-deploy.ts
+++ b/scripts/deployment-deploy.ts
@@ -38,12 +38,14 @@ await compileBinary({
   outputFileName: "bin-aarch64-Darwin",
 })
 
-// In order for the github release deployment script to be able to create a release with these assets, we need to update the input object to include them.
-const outputFileForDeployment = JSON.parse(new TextDecoder("utf-8").decode(Deno.readFileSync(Deno.env.get("DATA_FILE_PATH")!)));
-outputFileForDeployment["@levibostian/decaf-script-github-releases"]["githubReleaseAssets"] = githubReleaseAssets
-
-// Write the updated input back to the file so that the deployment script can read it.
-Deno.writeFileSync(Deno.env.get("DATA_FILE_PATH")!, new TextEncoder().encode(JSON.stringify(outputFileForDeployment)))
+await $`deno ${[
+  `run`,
+  `--quiet`,
+  `--allow-all`,
+  `script.ts`,
+  `set-github-release-assets`,
+  ...githubReleaseAssets
+]}`.printCommand()
 
 // ---------------------------------------------------------------------------------
 // Publish the deno module to jsr
@@ -90,3 +92,20 @@ if (didAlreadyDeployToNpm) {
 } else {
   await $`npm ${argsToPushToNpm}`.printCommand()
 }
+
+// ---------------------------------------------------------------------------------
+// Create the GitHub Release
+// ---------------------------------------------------------------------------------
+
+await $`deno ${[
+  `run`,
+  `--quiet`,
+  `--allow-all`,
+  `script.ts`,
+  `set-latest-release`,
+  `--generate-notes`,
+  `--latest`,
+  `--target`,
+  `${input.gitCurrentBranch}`
+]}`.printCommand()
+


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

In order to make this tool the most useful for being a tool that's supposed to work with GitHub releases, you need to be able to create new releases, not just get them. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Added a new command, technically two commands, to be able to upload assets to the release. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

running script in this PR

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->