### PR TITLE
fix: install script attached to github releases

### DIFF
--- a/install.template
+++ b/install.template
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 VERSION="PUT_VERSION_HERE"
 REPO="levibostian/decaf-script-github-releases"
@@ -29,7 +29,7 @@ DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$BINARY_FILE"
 DEST="$INSTALL_DIR/$BINARY_NAME"
 
 if ! curl -fsSL "$DOWNLOAD_URL" -o "$DEST"; then
-    echo -e "404 - $DOWNLOAD_URL" >&2
+    printf "404 - %s\n" "$DOWNLOAD_URL" >&2
     exit 1
 fi
 chmod +x "$DEST"

--- a/shebang.sh
+++ b/shebang.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 # Script that runs via decaf's shebang feature.
 


### PR DESCRIPTION
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

error I got when running install script from shebang:
`sh: 2: set: Illegal option -o pipefail`

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Fix the install script. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

I ran `sh install.template` as my way to test the script. This is because you must use `sh` as that's what the `curl... | sh` command does in `shebang.sh` file. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->